### PR TITLE
Stop relying on the default API Keys used by ethers

### DIFF
--- a/interface/packages/react-app/.gitignore
+++ b/interface/packages/react-app/.gitignore
@@ -1,0 +1,21 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+coverage
+
+# production
+build
+
+# misc
+.DS_Store
+.env*
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/interface/packages/react-app/src/App.js
+++ b/interface/packages/react-app/src/App.js
@@ -10,7 +10,12 @@ import { logoutOfWeb3Modal, web3Modal } from './utils/web3Modal';
 
 async function readOnChainData() {
   // Should replace with the end-user wallet, e.g. Metamask
-  const defaultProvider = getDefaultProvider();
+  const network = "homestead" // mainnet
+  const defaultProvider = getDefaultProvider(network, {
+    etherscan: process.env.REACT_APP_ETHERSCAN_API_KEY,
+    infura: process.env.REACT_APP_INFURA_PROJECT_ID,
+    alchemy: process.env.REACT_APP_ALCHEMY_API_KEY
+  });
   // Create an instance of an ethers.js Contract
   // Read more about ethers.js on https://docs.ethers.io/v5/api/contract/contract/
   const daiWethExchangeContract = new Contract(addresses[MAINNET_ID].pairs["DAI-WETH"], abis.pair, defaultProvider);
@@ -69,7 +74,7 @@ function App() {
           Edit <code>packages/react-app/src/App.js</code> and save to reload.
         </p>
         {/* Remove the "hidden" prop and open the JavaScript console in the browser to see what this function does */}
-        <Button hidden onClick={() => readOnChainData()}>
+        <Button onClick={() => readOnChainData()}>
           Read On-Chain Reserves
         </Button>
         <Link

--- a/interface/packages/react-app/src/App.js
+++ b/interface/packages/react-app/src/App.js
@@ -1,14 +1,12 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { Contract } from "@ethersproject/contracts";
-import { Web3Provider, getDefaultProvider } from "@ethersproject/providers";
 import { useQuery } from "@apollo/react-hooks";
-
+import { Contract } from "@ethersproject/contracts";
+import { getDefaultProvider, Web3Provider } from "@ethersproject/providers";
+import { abis, addresses, MAINNET_ID } from "@uniswap-v2-app/contracts";
+import React, { useCallback, useEffect, useState } from "react";
 import { Body, Button, Header, Image, Link } from "./components";
-import { web3Modal, logoutOfWeb3Modal } from './utils/web3Modal'
 import logo from "./ethereumLogo.png";
-
-import { MAINNET_ID, addresses, abis } from "@uniswap-v2-app/contracts";
 import GET_AGGREGATED_UNISWAP_DATA from "./graphql/subgraph";
+import { logoutOfWeb3Modal, web3Modal } from './utils/web3Modal';
 
 async function readOnChainData() {
   // Should replace with the end-user wallet, e.g. Metamask


### PR DESCRIPTION
Add our own, project-specific, Etherscan, Infura, and Alchemy API keys.