### PR TITLE
smart contracts

### DIFF
--- a/contracts/contracts/VaultsManager.sol
+++ b/contracts/contracts/VaultsManager.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+import "./OpynV2Helpers.sol";
+
+import {Actions} from "./libs/Actions.sol";
+
+contract VaultsManager is OpynV2Helpers {
+    address[3] public validCollateral;
+    mapping(address => uint256) public ownedVaults;
+
+    enum Collateral {USDC, cUSDC, WETH}
+
+    constructor(address _OpynV2AddressBook, address[3] memory _validCollateral)
+        OpynV2Helpers(_OpynV2AddressBook)
+    {
+        validCollateral = _validCollateral;
+    }
+
+    function createCollateralizedVault(
+        Collateral _assetToDeposit,
+        uint256 _amount
+    ) public {}
+}

--- a/interface/packages/react-app/package.json
+++ b/interface/packages/react-app/package.json
@@ -42,6 +42,7 @@
     "prop-types": "^15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
+    "react-modal": "^3.11.2",
     "react-plotly.js": "^2.5.0",
     "react-router": "^6.0.0-beta.0",
     "react-router-dom": "^6.0.0-beta.0",

--- a/interface/packages/react-app/src/App.jsx
+++ b/interface/packages/react-app/src/App.jsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Body, Header } from './components';
 import OptionsILGraph from './components/OptionsILGraph';
+import OptionsSeller from './components/OptionsSeller';
 import WalletButton from './components/WalletButton';
 import { web3Modal } from './utils/web3Modal';
 
@@ -32,16 +33,20 @@ function App() {
       <Header>
         <WalletButton web3Provider={provider} loadWeb3Modal={loadWeb3Modal} />
       </Header>
-      <Routes>
-        <Body>
+      <Body>
+        <Routes>
           <Route
             path="/"
             element={
               <OptionsILGraph web3Provider={provider ?? DEFAULT_PROVIDER} />
             }
           />
-        </Body>
-      </Routes>
+          <Route
+            path="sell/"
+            element={<OptionsSeller web3Provider={provider} />}
+          />
+        </Routes>
+      </Body>
     </BrowserRouter>
   );
 }

--- a/interface/packages/react-app/src/components/OptionsSeller/OptionsSeller.jsx
+++ b/interface/packages/react-app/src/components/OptionsSeller/OptionsSeller.jsx
@@ -1,0 +1,66 @@
+import { Web3Provider } from '@ethersproject/providers';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import Modal from 'react-modal';
+
+const modalStyles = {
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+  },
+};
+
+const rinkebyId = 4;
+
+// set the aria-hidden attribute while the modal is open
+Modal.setAppElement('#root');
+
+function OptionsSeller({ web3Provider }) {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+
+  useEffect(() => {
+    const changeModal = async () => {
+      if (web3Provider === null) {
+        setModalMessage('Please connect your Web3 Wallet');
+        setModalIsOpen(true);
+        return;
+      }
+      const currentNetwork = await web3Provider.getNetwork();
+      if (currentNetwork.chainId !== rinkebyId) {
+        setModalMessage(
+          'Please change your wallet connection to the Rinkeby Test Net'
+        );
+        setModalIsOpen(true);
+        return;
+      }
+      setModalIsOpen(false);
+    };
+
+    changeModal();
+  }, [web3Provider]);
+
+  console.log(web3Provider !== null ? 'not null' : 'is null');
+  console.log(web3Provider);
+
+  return (
+    <Modal
+      isOpen={modalIsOpen}
+      onRequestClose={() => setModalIsOpen(false)}
+      style={modalStyles}
+      contentLabel="Web3 Provider Alerts"
+    >
+      <div>{modalMessage}</div>
+    </Modal>
+  );
+}
+
+OptionsSeller.propTypes = {
+  web3Provider: PropTypes.instanceOf(Web3Provider),
+};
+
+export default OptionsSeller;

--- a/interface/packages/react-app/src/components/OptionsSeller/index.jsx
+++ b/interface/packages/react-app/src/components/OptionsSeller/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './OptionsSeller';

--- a/interface/yarn.lock
+++ b/interface/yarn.lock
@@ -6565,6 +6565,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -12658,7 +12663,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12956,6 +12961,21 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-modal@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
+  integrity sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^4.0.3"
 
 react-plotly.js@^2.5.0:
   version "2.5.0"
@@ -15647,6 +15667,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Add initial smart contracts to interact with OpynV2
- Format contract artifacts
- Add chai as a dev dependency
- Add truffle scripts
- Add initial test for the OpynV2Helpers contract
- Add NatSpec documentation
- Update test
- Remove inline ABI
- Add Opyn v2 libs
- Add an interface for the Opyn v2 Controller contract
- Add contract that will implement the options strategies (straddle, strangle)
- Update test and migration
- Update artifacts and rename test
- Methods for retrieving Opyn weth option prices.  Currently stubbed graphql call.
- Get options only on the first render
- Organize components
- Clean up
- Revert "Clean up"
- Move the WalletButton component and do some clean-up
- Hook up live price data
- Get data from the Chainlink ETH/USD price feed
- Update names and descriptions
- Update images
- Update packages' names and README
- Add the react-router dependency
- Change file extensions: .js -> .jsx
- Add ESLint and lint the entire codebase
- Configure Husky
- Fix Husky configuration
- Additional linting
- Move plot to its own component
- Fallback to a default provider
- Fix providers and addresses
- Fix imports
- Add a Router to the app
- Start implementing a contract to manage Opyn V2 vaults
- Add a new Route and make sure that the user is connected to Rinkeby
